### PR TITLE
change the grind deps

### DIFF
--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -32,7 +32,7 @@ bower() {
 }
 
 @DefaultTask('Test')
-@Depends('bower')
+@Depends(bower)
 test() =>
     new TestRunner().test(
         files: allFiles,
@@ -41,9 +41,9 @@ test() =>
 @Task("Serve polymerjs examples.")
 examples() {
   run("pub", arguments: ["get"],
-  runOptions: new RunOptions(workingDirectory: "polymerjs_examples"));
+      runOptions: new RunOptions(workingDirectory: "polymerjs_examples"));
   run("bower", arguments: ["install"],
-  runOptions: new RunOptions(workingDirectory: "polymerjs_examples"));
+      runOptions: new RunOptions(workingDirectory: "polymerjs_examples"));
   runAsync("pub", arguments: ["serve"],
-  runOptions: new RunOptions(workingDirectory: "polymerjs_examples"));
+      runOptions: new RunOptions(workingDirectory: "polymerjs_examples"));
 }


### PR DESCRIPTION
Change the `test` to depend on `bower` instead of `'bower'`. It's essentially the same dep., but will survive things like refactoring the name of the `bower` task function better.
